### PR TITLE
#!/bin/bash => #!/usr/bin/env bash

### DIFF
--- a/packager/packager.sh
+++ b/packager/packager.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Copyright (c) 2015-present, Facebook, Inc.
 # All rights reserved.


### PR DESCRIPTION
Not all platforms have Bash in `/bin/bash`. This change makes `npm start` work on e.g. NixOS.
